### PR TITLE
Fix lint watch

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -7,9 +7,30 @@ const autoprefixer = require('autoprefixer')
 const cssnano = require('cssnano')
 const comments = require('postcss-discard-comments')
 const rename = require('gulp-rename')
+const stylelint = require('gulp-stylelint')
 
 // Declare base functions.
 const css = {
+  /**
+   * Runs stylelint on a provided source.
+   *
+   * @param   {(String | String[])} source        - The source path(s).
+   * @param   {Boolean}             [fix = false] - Toggle the fix option for stylelint.
+   *
+   * @returns {Object} - Gulp stream.
+   */
+  lint: (source, fix = false) => {
+    const stream = src(source, { base: './' })
+      .pipe(stylelint({
+        reporters: [{ formatter: 'verbose', console: true }],
+        fix: fix
+      }))
+
+    // Only pipe out to destination if fix is enabled.
+    if (fix) stream.pipe(dest('.'))
+
+    return stream
+  },
   /**
    * Runs postcss/autoprefixer on a provided source and outputs the result.
    *

--- a/src/js.js
+++ b/src/js.js
@@ -18,11 +18,15 @@ const js = {
    * @returns {Object} - Gulp stream.
    */
   lint: (source, fix = false) => {
-    return src(source, { base: './' })
+    const stream = src(source, { base: './' })
       .pipe(eslint({ fix: fix }))
       .pipe(eslint.format())
       .pipe(eslint.failAfterError())
-      .pipe(dest('.'))
+
+    // Only pipe out to destination if fix is enabled.
+    if (fix) stream.pipe(dest('.'))
+
+    return stream
   },
   /**
    * Runs babel on a provided source and outputs the result.

--- a/src/sass.js
+++ b/src/sass.js
@@ -8,7 +8,7 @@ const stylelint = require('gulp-stylelint')
 // Declare base functions.
 const sass = {
   /**
-   * Runs sass-lint on a provided source.
+   * Runs stylelint on a provided source.
    *
    * @param   {(String | String[])} source        - The source path(s).
    * @param   {Boolean}             [fix = false] - Toggle the fix option for stylelint.
@@ -16,12 +16,16 @@ const sass = {
    * @returns {Object} - Gulp stream.
    */
   lint: (source, fix = false) => {
-    return src(source, { base: './' })
+    const stream = src(source, { base: './' })
       .pipe(stylelint({
         reporters: [{ formatter: 'verbose', console: true }],
         fix: fix
       }))
-      .pipe(dest('.'))
+
+    // Only pipe out to destination if fix is enabled.
+    if (fix) stream.pipe(dest('.'))
+
+    return stream
   },
   /**
    * Runs sass and on a provided source and outputs the result.


### PR DESCRIPTION
## Description

Lint tasks always output to a destination, causing watch functions to continuously loop. This adds a check for the `fix` variable to be true before piping to the destination.

## Related Issues

Fixes #5 