### PR TITLE
build(config): move commitlint config into package.json

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,1 +1,0 @@
-module.exports = {extends: ['@commitlint/config-conventional']}

--- a/package.json
+++ b/package.json
@@ -71,10 +71,15 @@
       "sourceType": "module"
     }
   },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "npm run lint"
+      "pre-commit": "echo committing as $(git config user.name) && npm run lint"
     }
   }
 }


### PR DESCRIPTION
## Description

Moving the config into the package.json will keep things nice and clean for such a small package.
