### PR TITLE
feat(source): combine parameters into single object

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -14,12 +14,13 @@ const css = {
   /**
    * Runs stylelint on a provided source.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
+   * @param   {Object}              param0                      - The path options.
+   * @param   {(String | String[])} param0.source               - The source path(s).
+   * @param   {Object}              [param0.sourceOptions = {}] - Options for the source.
    *
    * @returns {Object} - Gulp stream.
    */
-  lint: (source, sourceOptions = {}) => {
+  lint: ({ source, sourceOptions = {} }) => {
     return src(source, sourceOptions)
       .pipe(stylelint({
         reporters: [{ formatter: 'verbose', console: true }]
@@ -28,14 +29,15 @@ const css = {
   /**
    * Runs stylelint:fix on a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  fix: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  fix: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'
@@ -51,14 +53,15 @@ const css = {
   /**
    * Runs postcss/autoprefixer on a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  compile: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  compile: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'
@@ -71,14 +74,15 @@ const css = {
   /**
    * Minifies and renames a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  minify: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  minify: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'

--- a/src/js.js
+++ b/src/js.js
@@ -12,12 +12,13 @@ const js = {
   /**
    * Runs eslint on a provided source.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
+   * @param   {Object}              param0                      - The path options.
+   * @param   {(String | String[])} param0.source               - The source path(s).
+   * @param   {Object}              [param0.sourceOptions = {}] - Options for the source.
    *
    * @returns {Object} - Gulp stream.
    */
-  lint: (source, sourceOptions = {}) => {
+  lint: ({ source, sourceOptions = {} }) => {
     return src(source, sourceOptions)
       .pipe(eslint())
       .pipe(eslint.format())
@@ -26,14 +27,15 @@ const js = {
   /**
    * Runs eslint:fix on a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  fix: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  fix: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'
@@ -48,14 +50,15 @@ const js = {
   /**
    * Runs babel on a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  compile: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  compile: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'
@@ -68,14 +71,15 @@ const js = {
   /**
    * Minifies and renames a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  minify: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  minify: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'

--- a/src/lib.js
+++ b/src/lib.js
@@ -4,14 +4,15 @@ const lib = {
   /**
    * Gathers source files and outputs them to a provided destination.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String}              destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  fetch: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  fetch: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     return src(source, sourceOptions)
       .pipe(dest(destination, destinationOptions))
   }

--- a/src/sass.js
+++ b/src/sass.js
@@ -10,12 +10,13 @@ const sass = {
   /**
    * Runs stylelint on a provided source.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
+   * @param   {Object}              param0                      - The path options.
+   * @param   {(String | String[])} param0.source               - The source path(s).
+   * @param   {Object}              [param0.sourceOptions = {}] - Options for the source.
    *
    * @returns {Object} - Gulp stream.
    */
-  lint: (source, sourceOptions = {}) => {
+  lint: ({ source, sourceOptions = {} }) => {
     return src(source, sourceOptions)
       .pipe(stylelint({
         reporters: [{ formatter: 'verbose', console: true }]
@@ -24,14 +25,15 @@ const sass = {
   /**
    * Runs stylelint:fix on a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  fix: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  fix: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'
@@ -47,14 +49,15 @@ const sass = {
   /**
    * Runs sass and on a provided source and outputs the result.
    *
-   * @param   {(String | String[])} source                    - The source path(s).
-   * @param   {String | Null}       destination               - The destination path.
-   * @param   {Object}              [sourceOptions = {}]       - Options for the source.
-   * @param   {Object}              [destinationOptions = {}] - Options for the destination.
+   * @param   {Object}              param0                           - The path options.
+   * @param   {(String | String[])} param0.source                    - The source path(s).
+   * @param   {String | Null}       param0.destination               - The destination path.
+   * @param   {Object}              [param0.sourceOptions = {}]      - Options for the source.
+   * @param   {Object}              [param0.destinationOptions = {}] - Options for the destination.
    *
    * @returns {Object} - Gulp stream.
    */
-  compile: (source, destination, sourceOptions = {}, destinationOptions = {}) => {
+  compile: ({ source, destination, sourceOptions = {}, destinationOptions = {} }) => {
     if (!destination) {
       if (!sourceOptions.base) sourceOptions.base = './'
       destination = '.'


### PR DESCRIPTION
BREAKING CHANGE: Combining all parameters into a single object will cause all existing projects
using the templates to fail due to the expected input changes.

## Description

All parameters (source, destination, options...) have been combined into a single object that is passed in. This allows for a couple of improvements:

* The ability to declare destinationOptions without needing to worry about sourceOptions, and
* Allows greater control for complex gulp tasks
